### PR TITLE
fix: deviceName is now changed automatically

### DIFF
--- a/src/experiment.cpp
+++ b/src/experiment.cpp
@@ -31,11 +31,6 @@ void PhyphoxBleExperiment::setConfig(const char *t){
 	strcat(CONFIG, t);
 }
 
-void PhyphoxBleExperiment::setDeviceName(const char *d){
-	memset(&DEVICENAME[0], 0, sizeof(DEVICENAME));
-	strcat(DEVICENAME, d);
-}
-
 void PhyphoxBleExperiment::addExportSet(ExportSet& e)
 {
 	for(int i=0; i<phyphoxBleNExportSets; i++)
@@ -47,7 +42,7 @@ void PhyphoxBleExperiment::addExportSet(ExportSet& e)
 	}
 }
 
-void PhyphoxBleExperiment::getFirstBytes(char *buffArray){
+void PhyphoxBleExperiment::getFirstBytes(char *buffArray, const char *DEVICENAME){
 	//header
 	strcat(buffArray, "<phyphox version=\"1.10\">\n");
 	//build title

--- a/src/phyphoxBLE_ESP32.cpp
+++ b/src/phyphoxBLE_ESP32.cpp
@@ -96,6 +96,7 @@ void PhyphoxBLE::start(uint8_t* exp_pointer, size_t len){
 
 void PhyphoxBLE::start(const char * DEVICE_NAME)
 {
+  deviceName = DEVICE_NAME;
   if(printer){
     printer -> println("starting server");
   }
@@ -307,7 +308,7 @@ void PhyphoxBLE::addExperiment(PhyphoxBleExperiment& exp)
   char buffer[2000] ="";
   uint16_t length = 0;
 
-	exp.getFirstBytes(buffer);
+	exp.getFirstBytes(buffer, deviceName);
 	memcpy(&EXPARRAY[length],&buffer[0],strlen(buffer));
   length += strlen(buffer);
   memset(&(buffer[0]), NULL, strlen(buffer));

--- a/src/phyphoxBLE_NRF52.cpp
+++ b/src/phyphoxBLE_NRF52.cpp
@@ -267,6 +267,7 @@ void PhyphoxBLE::start(uint8_t* exp_pointer, size_t len) {
 
 void PhyphoxBLE::start(const char* DEVICE_NAME) {
     start(DEVICE_NAME, nullptr, 0);
+	deviceName = DEVICE_NAME;
 }
 
 void PhyphoxBLE::start() {
@@ -376,7 +377,7 @@ void PhyphoxBLE::addExperiment(PhyphoxBleExperiment& exp)
   char buffer[2000] ="";
   uint16_t length = 0;
 
-	exp.getFirstBytes(buffer);
+	exp.getFirstBytes(buffer, deviceName);
 	memcpy(&EXPARRAY[length],&buffer[0],strlen(buffer));
   length += strlen(buffer);
   memset(&(buffer[0]), NULL, strlen(buffer));

--- a/src/phyphoxBLE_NanoIOT.cpp
+++ b/src/phyphoxBLE_NanoIOT.cpp
@@ -39,6 +39,7 @@ void PhyphoxBLE::start(uint8_t* exp_pointer, size_t len){
 
 void PhyphoxBLE::start(const char* DEVICE_NAME)
 {
+  deviceName = DEVICE_NAME;
 
   controlCharacteristic.setEventHandler(BLEWritten, controlCharacteristicWritten);
   configCharacteristic.setEventHandler(BLEWritten, configCharacteristicWritten);
@@ -115,7 +116,7 @@ void PhyphoxBLE::addExperiment(PhyphoxBleExperiment& exp)
   char buffer[2000] ="";
   uint16_t length = 0;
 
-	exp.getFirstBytes(buffer);
+	exp.getFirstBytes(buffer, deviceName);
 	memcpy(&EXPARRAY[length],&buffer[0],strlen(buffer));
   length += strlen(buffer);
   memset(&(buffer[0]), NULL, strlen(buffer));

--- a/src/phyphoxBle.h
+++ b/src/phyphoxBle.h
@@ -9,6 +9,8 @@ static const char *phyphoxBleDataServiceUUID = "cddf1001-30f7-4671-8b43-5e40ba53
 static const char *phyphoxBleDataCharacteristicUUID = "cddf1002-30f7-4671-8b43-5e40ba53514a";
 static const char *phyphoxBleConfigCharacteristicUUID = "cddf1003-30f7-4671-8b43-5e40ba53514a";
 
+static const char *deviceName = "phyphox-Arduino";
+
 
 #ifndef CONFIGSIZE
 #define CONFIGSIZE 20

--- a/src/phyphoxBleExperiment.h
+++ b/src/phyphoxBleExperiment.h
@@ -235,10 +235,9 @@ public:
 	void setCategory(const char *);
 	void setDescription(const char *);
 	void setConfig(const char *);
-	void setDeviceName(const char *);
 
 	void getBytes(char *);
-	void getFirstBytes(char *);
+	void getFirstBytes(char *, const char *);
 	void getViewBytes(char *, uint8_t, uint8_t);
 	void getLastBytes(char *);
 	void addView(View &);
@@ -249,7 +248,6 @@ public:
 	char CATEGORY[50] = "Arduino Experiments";
 	char DESCRIPTION[500] = "An experiment created with the phyphox BLE library for Arduino-compatible micro controllers.";
 	char CONFIG[8] = "000000";
-	char DEVICENAME[20] = "MyDevice";
 
 	View *VIEWS[phyphoxBleNViews] = {nullptr};
 	ExportSet *EXPORTSETS[phyphoxBleNExportSets] = {nullptr};


### PR DESCRIPTION
deviceName should now be changed automatically when PhyphoxBLE::start() is called.